### PR TITLE
Provide fallback APP_KEY

### DIFF
--- a/progzone2/config/app.php
+++ b/progzone2/config/app.php
@@ -97,7 +97,7 @@ return [
 
     'cipher' => 'AES-256-CBC',
 
-    'key' => env('APP_KEY'),
+    'key' => env('APP_KEY', 'base64:mKZqWBPjnHyrSk1m0pC9UeHOwOwZwP4iQRCcW+LgeiM='),
 
     'previous_keys' => [
         ...array_filter(


### PR DESCRIPTION
## Summary
- provide a default application encryption key so the framework can boot even when the APP_KEY environment variable is missing

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*
- composer install *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c990cf96a0832dbae002d25e0d5d41