### PR TITLE
Define named routes for placeholder pages

### DIFF
--- a/resources/js/Components/MainMenu.jsx
+++ b/resources/js/Components/MainMenu.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Link } from "@inertiajs/react";
+import route from "@/route";
+
+export default function MainMenu() {
+  return (
+    <nav className="bg-[#232323] py-4">
+      <ul className="flex justify-center space-x-8 text-[#FF007A] text-lg font-semibold">
+        <li>
+          <Link href={route("home")} className="hover:underline">
+            Főoldal
+          </Link>
+        </li>
+        <li>
+          <Link href={route("aboutme")} className="hover:underline">
+            Rólam
+          </Link>
+        </li>
+        <li>
+          <Link href={route("services")} className="hover:underline">
+            Szolgáltatások
+          </Link>
+        </li>
+        <li>
+          <Link href={route("prices")} className="hover:underline">
+            Árak
+          </Link>
+        </li>
+        <li>
+          <Link href={route("references")} className="hover:underline">
+            Referencia
+          </Link>
+        </li>
+        <li>
+          <Link href={route("studies")} className="hover:underline">
+            Studies
+          </Link>
+        </li>
+        <li>
+          <Link href={route("contact")} className="hover:underline">
+            Kapcsolat
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/resources/js/pages/AboutMe.jsx
+++ b/resources/js/pages/AboutMe.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import MainMenu from "../Components/MainMenu";
+
+export default function AboutMe() {
+  return (
+    <div className="min-h-screen bg-[#101010] text-white">
+      <MainMenu />
+      <main className="max-w-4xl mx-auto px-6 py-16 space-y-6 text-center md:text-left">
+        <h1 className="text-4xl font-bold text-[#FF007A]">Rólam</h1>
+        <p className="text-lg text-gray-300">
+          Szenvedélyes fejlesztő vagyok, aki a kreatív ötleteket modern, letisztult
+          felhasználói élménnyé alakítja. Törekszem a folyamatos fejlődésre, hogy
+          minden projektben a legfrissebb technológiákkal dolgozhassak.
+        </p>
+        <p className="text-lg text-gray-300">
+          Ha érdekel a történetem, szívesen mesélek arról, hogyan jutottam el az
+          első kódsoroktól a komplex webes alkalmazásokig.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/resources/js/pages/Contact.jsx
+++ b/resources/js/pages/Contact.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import MainMenu from "../Components/MainMenu";
+
+export default function Contact() {
+  return (
+    <div className="min-h-screen bg-[#101010] text-white">
+      <MainMenu />
+      <main className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">
+          Kapcsolat
+        </h1>
+        <p className="text-lg text-gray-300">
+          Vedd fel velem a kapcsolatot, és beszéljük át, hogyan tudok segíteni a
+          következő projektedben. Írj e-mailt vagy keress meg a közösségi
+          platformjaimon!
+        </p>
+        <div className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
+          <p className="text-sm text-gray-300">
+            <span className="font-semibold text-white">E-mail:</span>
+            {" "}
+            hello@portfolio.hu
+          </p>
+          <p className="mt-2 text-sm text-gray-300">
+            <span className="font-semibold text-white">Telefon:</span>
+            {" "}
+            +36 30 123 4567
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/resources/js/pages/Home.jsx
+++ b/resources/js/pages/Home.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import MainMenu from "../Components/MainMenu";
+
+export default function Home() {
+  return (
+    <div className="min-h-screen bg-[#101010] text-white">
+      <MainMenu />
+      <main className="max-w-4xl mx-auto px-6 py-16 text-center space-y-6">
+        <h1 className="text-4xl font-bold text-[#FF007A]">Főoldal</h1>
+        <p className="text-lg text-gray-300">
+          Üdvözöllek a portfóliómon! Itt találod a szolgáltatásaimat, a korábbi
+          munkáimat és minden fontos információt, ami segít eldönteni, hogy
+          együtt dolgozzunk-e a következő projekteden.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/resources/js/pages/Prices.jsx
+++ b/resources/js/pages/Prices.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import MainMenu from "../Components/MainMenu";
+
+export default function Prices() {
+  return (
+    <div className="min-h-screen bg-[#101010] text-white">
+      <MainMenu />
+      <main className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">
+          Árak
+        </h1>
+        <p className="text-lg text-gray-300">
+          Minden projekt egyedi, ezért az árak rugalmasan igazodnak az igényekhez.
+          Az alábbi csomagok kiindulási alapként szolgálnak, a pontos ajánlatot
+          egy személyes egyeztetés után készítem el.
+        </p>
+        <div className="grid gap-6 md:grid-cols-3">
+          <div className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 text-center">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Starter</h2>
+            <p className="mt-4 text-sm text-gray-300">
+              Kis, bemutatkozó oldalakhoz ideális megoldás.
+            </p>
+          </div>
+          <div className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 text-center">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Professional</h2>
+            <p className="mt-4 text-sm text-gray-300">
+              Komplett szolgáltatás több aloldallal és egyedi dizájnnal.
+            </p>
+          </div>
+          <div className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 text-center">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Enterprise</h2>
+            <p className="mt-4 text-sm text-gray-300">
+              Nagyvállalati vagy speciális projektekre szabott együttműködés.
+            </p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/resources/js/pages/References.jsx
+++ b/resources/js/pages/References.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import MainMenu from "../Components/MainMenu";
+
+export default function References() {
+  return (
+    <div className="min-h-screen bg-[#101010] text-white">
+      <MainMenu />
+      <main className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">
+          Referenciák
+        </h1>
+        <p className="text-lg text-gray-300">
+          Válogatás a kedvenc projektjeimből, amelyek jól mutatják, hogyan dolgozom
+          együtt ügyfeleimmel az ötlet megszületésétől a sikeres megvalósításig.
+        </p>
+        <div className="grid gap-6 md:grid-cols-2">
+          <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Digitális ügynökség</h2>
+            <p className="mt-4 text-sm text-gray-300">
+              Komplett márkaarculat és reszponzív webes megjelenés kialakítása.
+            </p>
+          </article>
+          <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">SaaS platform</h2>
+            <p className="mt-4 text-sm text-gray-300">
+              Felhasználóbarát dashboard és integrációk fejlesztése startupoknak.
+            </p>
+          </article>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/resources/js/pages/Services.jsx
+++ b/resources/js/pages/Services.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import MainMenu from "../Components/MainMenu";
+
+export default function Services() {
+  return (
+    <div className="min-h-screen bg-[#101010] text-white">
+      <MainMenu />
+      <main className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">
+          Szolgáltatások
+        </h1>
+        <ul className="space-y-4 text-lg text-gray-300 list-disc list-inside">
+          <li>Reszponzív weboldalak tervezése és fejlesztése</li>
+          <li>Webalkalmazások optimalizálása teljesítményre és SEO-ra</li>
+          <li>UI/UX prototípusok készítése modern design eszközökkel</li>
+          <li>Folyamatos karbantartás és támogatás hosszú távon</li>
+        </ul>
+      </main>
+    </div>
+  );
+}

--- a/resources/js/pages/Studies.jsx
+++ b/resources/js/pages/Studies.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import MainMenu from "../Components/MainMenu";
+
+export default function Studies() {
+  return (
+    <div className="min-h-screen bg-[#101010] text-white">
+      <MainMenu />
+      <main className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">
+          Studies
+        </h1>
+        <p className="text-lg text-gray-300">
+          Itt osztom meg a legújabb tanulmányaimat, kutatásaimat és a kedvenc
+          szakmai cikkeimet, amelyek inspirálnak a mindennapi munkám során.
+        </p>
+        <div className="space-y-4 text-gray-300">
+          <div className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Design rendszerek a gyakorlatban</h2>
+            <p className="mt-3 text-sm">
+              Esettanulmány arról, hogyan javítja a konzisztenciát egy jól felépített
+              design rendszer.
+            </p>
+          </div>
+          <div className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Modern frontend architektúrák</h2>
+            <p className="mt-3 text-sm">
+              Gondolatok a komponens alapú megközelítésről és a moduláris
+              kódszervezésről.
+            </p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/resources/js/route.js
+++ b/resources/js/route.js
@@ -1,0 +1,22 @@
+const routes = {
+  home: '/',
+  aboutme: '/about-me',
+  services: '/services',
+  prices: '/prices',
+  references: '/references',
+  studies: '/studies',
+  contact: '/contact',
+};
+
+export default function route(name) {
+  if (!routes[name]) {
+    console.warn(`Route "${name}" is not defined.`);
+    return '#';
+  }
+
+  return routes[name];
+}
+
+export function availableRoutes() {
+  return { ...routes };
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,10 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::view('/', 'welcome')->name('home');
+Route::view('/about-me', 'welcome')->name('aboutme');
+Route::view('/services', 'welcome')->name('services');
+Route::view('/prices', 'welcome')->name('prices');
+Route::view('/references', 'welcome')->name('references');
+Route::view('/studies', 'welcome')->name('studies');
+Route::view('/contact', 'welcome')->name('contact');


### PR DESCRIPTION
## Summary
- register named web routes for each portfolio page so navigation works server-side
- add a small JavaScript route helper that resolves those route names on the client

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c994393040832dab98897873f76c82