### PR TITLE
Update layout structure

### DIFF
--- a/resources/js/Components/Layout.jsx
+++ b/resources/js/Components/Layout.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import FooterMenu from './FooterMenu.jsx';
+import Footer from './FooterMenu.jsx';
 import MainMenu from './MainMenu.jsx';
 
 export default function Layout({ activePath, children }) {
   return (
-    <div className="min-h-screen bg-[#101010] text-white flex flex-col">
+    <div className="min-h-screen text-[#FF007A] flex flex-col">
       <MainMenu activePath={activePath} />
-      <main className="flex-1 w-full">{children}</main>
-      <FooterMenu />
+      <main className="flex-grow flex items-center justify-center">{children}</main>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update the shared Layout component to match the requested structure with the pink theme
- center page content within the layout while keeping the main menu and footer

## Testing
- npm run build *(fails: existing issue `"default" is not exported by "resources/js/App.jsx", imported by "resources/js/App.jsx"`)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c583ecd0832d89675b2a3a1e8e28