### PR TITLE
Add layout with navigation to all pages

### DIFF
--- a/resources/js/Components/Layout.jsx
+++ b/resources/js/Components/Layout.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import { usePage } from '@inertiajs/react';
 import Footer from './FooterMenu.jsx';
 import MainMenu from './MainMenu.jsx';
 
 export default function Layout({ activePath, children }) {
+  const { url } = usePage();
+  const currentPath = activePath ?? url ?? '';
+
   return (
     <div className="min-h-screen text-[#FF007A] flex flex-col">
-      <MainMenu activePath={activePath} />
+      <MainMenu activePath={currentPath} />
       <main className="flex-grow flex items-center justify-center">{children}</main>
       <Footer />
     </div>

--- a/resources/js/pages/AboutMe.jsx
+++ b/resources/js/pages/AboutMe.jsx
@@ -1,17 +1,20 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function AboutMe() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6 text-center md:text-left">
-      <h1 className="text-4xl font-bold text-[#FF007A]">Rólam</h1>
-      <p className="text-lg text-gray-300">
-        Szenvedélyes fejlesztő vagyok, aki a kreatív ötleteket modern, letisztult felhasználói élménnyé alakítja.
-        Törekszem a folyamatos fejlődésre, hogy minden projektben a legfrissebb technológiákkal dolgozhassak.
-      </p>
-      <p className="text-lg text-gray-300">
-        Ha érdekel a történetem, szívesen mesélek arról, hogyan jutottam el az első kódsoroktól a komplex webes
-        alkalmazásokig.
-      </p>
-    </section>
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 space-y-6 text-center md:text-left">
+        <h1 className="text-4xl font-bold text-[#FF007A]">Rólam</h1>
+        <p className="text-lg text-gray-300">
+          Szenvedélyes fejlesztő vagyok, aki a kreatív ötleteket modern, letisztult felhasználói élménnyé alakítja.
+          Törekszem a folyamatos fejlődésre, hogy minden projektben a legfrissebb technológiákkal dolgozhassak.
+        </p>
+        <p className="text-lg text-gray-300">
+          Ha érdekel a történetem, szívesen mesélek arról, hogyan jutottam el az első kódsoroktól a komplex webes
+          alkalmazásokig.
+        </p>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/pages/Contact.jsx
+++ b/resources/js/pages/Contact.jsx
@@ -1,21 +1,24 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function Contact() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
-      <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Kapcsolat</h1>
-      <p className="text-lg text-gray-300">
-        Vedd fel velem a kapcsolatot, és beszéljük át, hogyan tudok segíteni a következő projektedben. Írj e-mailt vagy
-        keress meg a közösségi platformjaimon!
-      </p>
-      <div className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 space-y-2 text-sm text-gray-300">
-        <p>
-          <span className="font-semibold text-white">E-mail:</span> hello@portfolio.hu
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Kapcsolat</h1>
+        <p className="text-lg text-gray-300">
+          Vedd fel velem a kapcsolatot, és beszéljük át, hogyan tudok segíteni a következő projektedben. Írj e-mailt vagy
+          keress meg a közösségi platformjaimon!
         </p>
-        <p>
-          <span className="font-semibold text-white">Telefon:</span> +36 30 123 4567
-        </p>
-      </div>
-    </section>
+        <div className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 space-y-2 text-sm text-gray-300">
+          <p>
+            <span className="font-semibold text-white">E-mail:</span> hello@portfolio.hu
+          </p>
+          <p>
+            <span className="font-semibold text-white">Telefon:</span> +36 30 123 4567
+          </p>
+        </div>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/pages/Home.jsx
+++ b/resources/js/pages/Home.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function Home() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 text-center space-y-6">
-      <h1 className="text-4xl font-bold text-[#FF007A]">Főoldal</h1>
-      <p className="text-lg text-gray-300">
-        Üdvözöllek a portfóliómon! Itt találod a szolgáltatásaimat, a korábbi munkáimat és minden fontos
-        információt, ami segít eldönteni, hogy együtt dolgozzunk-e a következő projekteden.
-      </p>
-    </section>
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 text-center space-y-6">
+        <h1 className="text-4xl font-bold text-[#FF007A]">Főoldal</h1>
+        <p className="text-lg text-gray-300">
+          Üdvözöllek a portfóliómon! Itt találod a szolgáltatásaimat, a korábbi munkáimat és minden fontos
+          információt, ami segít eldönteni, hogy együtt dolgozzunk-e a következő projekteden.
+        </p>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/pages/Impressum.jsx
+++ b/resources/js/pages/Impressum.jsx
@@ -1,27 +1,30 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function Impressum() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
-      <h1 className="text-3xl font-bold text-[#FF007A]">Impresszum</h1>
-      <div className="space-y-2 text-lg text-gray-300">
-        <p>
-          <span className="font-semibold text-white">Név:</span> Progzone
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-3xl font-bold text-[#FF007A]">Impresszum</h1>
+        <div className="space-y-2 text-lg text-gray-300">
+          <p>
+            <span className="font-semibold text-white">Név:</span> Progzone
+          </p>
+          <p>
+            <span className="font-semibold text-white">E-mail:</span> hello@portfolio.hu
+          </p>
+          <p>
+            <span className="font-semibold text-white">Telefonszám:</span> +36 30 123 4567
+          </p>
+          <p>
+            <span className="font-semibold text-white">Székhely:</span> 1234 Budapest, Példa utca 1.
+          </p>
+        </div>
+        <p className="text-sm text-gray-300">
+          A weboldalon megjelenített tartalom a szerzői jogról szóló törvény hatálya alá esik. A tartalmak felhasználása
+          csak előzetes írásos engedéllyel lehetséges.
         </p>
-        <p>
-          <span className="font-semibold text-white">E-mail:</span> hello@portfolio.hu
-        </p>
-        <p>
-          <span className="font-semibold text-white">Telefonszám:</span> +36 30 123 4567
-        </p>
-        <p>
-          <span className="font-semibold text-white">Székhely:</span> 1234 Budapest, Példa utca 1.
-        </p>
-      </div>
-      <p className="text-sm text-gray-300">
-        A weboldalon megjelenített tartalom a szerzői jogról szóló törvény hatálya alá esik. A tartalmak felhasználása
-        csak előzetes írásos engedéllyel lehetséges.
-      </p>
-    </section>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/pages/Prices.jsx
+++ b/resources/js/pages/Prices.jsx
@@ -1,27 +1,30 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function Prices() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
-      <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Árak</h1>
-      <p className="text-lg text-gray-300">
-        Minden projekt egyedi, ezért az árak rugalmasan igazodnak az igényekhez. Az alábbi csomagok kiindulási
-        alapként szolgálnak, a pontos ajánlatot egy személyes egyeztetés után készítem el.
-      </p>
-      <div className="grid gap-6 md:grid-cols-3">
-        <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 text-center">
-          <h2 className="text-2xl font-semibold text-[#FF007A]">Starter</h2>
-          <p className="mt-4 text-sm text-gray-300">Kis, bemutatkozó oldalakhoz ideális megoldás.</p>
-        </article>
-        <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 text-center">
-          <h2 className="text-2xl font-semibold text-[#FF007A]">Professional</h2>
-          <p className="mt-4 text-sm text-gray-300">Komplett szolgáltatás több aloldallal és egyedi dizájnnal.</p>
-        </article>
-        <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 text-center">
-          <h2 className="text-2xl font-semibold text-[#FF007A]">Enterprise</h2>
-          <p className="mt-4 text-sm text-gray-300">Nagyvállalati vagy speciális projektekre szabott együttműködés.</p>
-        </article>
-      </div>
-    </section>
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Árak</h1>
+        <p className="text-lg text-gray-300">
+          Minden projekt egyedi, ezért az árak rugalmasan igazodnak az igényekhez. Az alábbi csomagok kiindulási
+          alapként szolgálnak, a pontos ajánlatot egy személyes egyeztetés után készítem el.
+        </p>
+        <div className="grid gap-6 md:grid-cols-3">
+          <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 text-center">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Starter</h2>
+            <p className="mt-4 text-sm text-gray-300">Kis, bemutatkozó oldalakhoz ideális megoldás.</p>
+          </article>
+          <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 text-center">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Professional</h2>
+            <p className="mt-4 text-sm text-gray-300">Komplett szolgáltatás több aloldallal és egyedi dizájnnal.</p>
+          </article>
+          <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6 text-center">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Enterprise</h2>
+            <p className="mt-4 text-sm text-gray-300">Nagyvállalati vagy speciális projektekre szabott együttműködés.</p>
+          </article>
+        </div>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/pages/Privacy.jsx
+++ b/resources/js/pages/Privacy.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function Privacy() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
-      <h1 className="text-3xl font-bold text-[#FF007A]">Adatvédelmi szerződés</h1>
-      <p className="text-lg text-gray-300">
-        A személyes adatok kezelése során minden esetben az érvényes jogszabályoknak és a legjobb gyakorlatnak
-        megfelelően járok el. Az adatok kizárólag a kapcsolattartáshoz és a szolgáltatás teljesítéséhez szükségesek.
-      </p>
-      <ul className="space-y-2 list-disc list-inside text-gray-300">
-        <li>Az adatokhoz kizárólag én férek hozzá.</li>
-        <li>Az adatokat soha nem adom át harmadik félnek.</li>
-        <li>A kapcsolattartáshoz használt információkat kérésre törlöm.</li>
-      </ul>
-    </section>
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-3xl font-bold text-[#FF007A]">Adatvédelmi szerződés</h1>
+        <p className="text-lg text-gray-300">
+          A személyes adatok kezelése során minden esetben az érvényes jogszabályoknak és a legjobb gyakorlatnak
+          megfelelően járok el. Az adatok kizárólag a kapcsolattartáshoz és a szolgáltatás teljesítéséhez szükségesek.
+        </p>
+        <ul className="space-y-2 list-disc list-inside text-gray-300">
+          <li>Az adatokhoz kizárólag én férek hozzá.</li>
+          <li>Az adatokat soha nem adom át harmadik félnek.</li>
+          <li>A kapcsolattartáshoz használt információkat kérésre törlöm.</li>
+        </ul>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/pages/References.jsx
+++ b/resources/js/pages/References.jsx
@@ -1,27 +1,30 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function References() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
-      <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Referenciák</h1>
-      <p className="text-lg text-gray-300">
-        Válogatás a kedvenc projektjeimből, amelyek jól mutatják, hogyan dolgozom együtt ügyfeleimmel az ötlet
-        megszületésétől a sikeres megvalósításig.
-      </p>
-      <div className="grid gap-6 md:grid-cols-2">
-        <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
-          <h2 className="text-2xl font-semibold text-[#FF007A]">Digitális ügynökség</h2>
-          <p className="mt-4 text-sm text-gray-300">
-            Komplett márkaarculat és reszponzív webes megjelenés kialakítása.
-          </p>
-        </article>
-        <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
-          <h2 className="text-2xl font-semibold text-[#FF007A]">SaaS platform</h2>
-          <p className="mt-4 text-sm text-gray-300">
-            Felhasználóbarát dashboard és integrációk fejlesztése startupoknak.
-          </p>
-        </article>
-      </div>
-    </section>
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Referenciák</h1>
+        <p className="text-lg text-gray-300">
+          Válogatás a kedvenc projektjeimből, amelyek jól mutatják, hogyan dolgozom együtt ügyfeleimmel az ötlet
+          megszületésétől a sikeres megvalósításig.
+        </p>
+        <div className="grid gap-6 md:grid-cols-2">
+          <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Digitális ügynökség</h2>
+            <p className="mt-4 text-sm text-gray-300">
+              Komplett márkaarculat és reszponzív webes megjelenés kialakítása.
+            </p>
+          </article>
+          <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">SaaS platform</h2>
+            <p className="mt-4 text-sm text-gray-300">
+              Felhasználóbarát dashboard és integrációk fejlesztése startupoknak.
+            </p>
+          </article>
+        </div>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/pages/Services.jsx
+++ b/resources/js/pages/Services.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function Services() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
-      <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Szolgáltatások</h1>
-      <ul className="space-y-4 list-disc list-inside text-lg text-gray-300">
-        <li>Reszponzív weboldalak tervezése és fejlesztése</li>
-        <li>Webalkalmazások optimalizálása teljesítményre és SEO-ra</li>
-        <li>UI/UX prototípusok készítése modern design eszközökkel</li>
-        <li>Folyamatos karbantartás és támogatás hosszú távon</li>
-      </ul>
-    </section>
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Szolgáltatások</h1>
+        <ul className="space-y-4 list-disc list-inside text-lg text-gray-300">
+          <li>Reszponzív weboldalak tervezése és fejlesztése</li>
+          <li>Webalkalmazások optimalizálása teljesítményre és SEO-ra</li>
+          <li>UI/UX prototípusok készítése modern design eszközökkel</li>
+          <li>Folyamatos karbantartás és támogatás hosszú távon</li>
+        </ul>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/pages/Studies.jsx
+++ b/resources/js/pages/Studies.jsx
@@ -1,27 +1,30 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function Studies() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
-      <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Studies</h1>
-      <p className="text-lg text-gray-300">
-        Itt osztom meg a legújabb tanulmányaimat, kutatásaimat és a kedvenc szakmai cikkeimet, amelyek inspirálnak a
-        mindennapi munkám során.
-      </p>
-      <div className="space-y-4 text-gray-300">
-        <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
-          <h2 className="text-2xl font-semibold text-[#FF007A]">Design rendszerek a gyakorlatban</h2>
-          <p className="mt-3 text-sm">
-            Esettanulmány arról, hogyan javítja a konzisztenciát egy jól felépített design rendszer.
-          </p>
-        </article>
-        <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
-          <h2 className="text-2xl font-semibold text-[#FF007A]">Modern frontend architektúrák</h2>
-          <p className="mt-3 text-sm">
-            Gondolatok a komponens alapú megközelítésről és a moduláris kódszervezésről.
-          </p>
-        </article>
-      </div>
-    </section>
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-4xl font-bold text-center text-[#FF007A] md:text-left">Studies</h1>
+        <p className="text-lg text-gray-300">
+          Itt osztom meg a legújabb tanulmányaimat, kutatásaimat és a kedvenc szakmai cikkeimet, amelyek inspirálnak a
+          mindennapi munkám során.
+        </p>
+        <div className="space-y-4 text-gray-300">
+          <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Design rendszerek a gyakorlatban</h2>
+            <p className="mt-3 text-sm">
+              Esettanulmány arról, hogyan javítja a konzisztenciát egy jól felépített design rendszer.
+            </p>
+          </article>
+          <article className="rounded-lg border border-[#FF007A]/30 bg-[#1A1A1A] p-6">
+            <h2 className="text-2xl font-semibold text-[#FF007A]">Modern frontend architektúrák</h2>
+            <p className="mt-3 text-sm">
+              Gondolatok a komponens alapú megközelítésről és a moduláris kódszervezésről.
+            </p>
+          </article>
+        </div>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/pages/Terms.jsx
+++ b/resources/js/pages/Terms.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
+import Layout from '../Components/Layout.jsx';
 
 export default function Terms() {
   return (
-    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
-      <h1 className="text-3xl font-bold text-[#FF007A]">Általános szerződési feltételek</h1>
-      <p className="text-lg text-gray-300">
-        Az együttműködés során törekszem az átlátható kommunikációra és a határidők pontos betartására. Az alábbi
-        pontok foglalják össze a legfontosabb feltételeket.
-      </p>
-      <ol className="space-y-2 list-decimal list-inside text-gray-300">
-        <li>A projekt részleteit és az árajánlatot írásban rögzítjük.</li>
-        <li>A határidők betartása közös felelősségünk.</li>
-        <li>A projekt lezárása után is biztosítok támogatást és karbantartást.</li>
-      </ol>
-    </section>
+    <Layout>
+      <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+        <h1 className="text-3xl font-bold text-[#FF007A]">Általános szerződési feltételek</h1>
+        <p className="text-lg text-gray-300">
+          Az együttműködés során törekszem az átlátható kommunikációra és a határidők pontos betartására. Az alábbi
+          pontok foglalják össze a legfontosabb feltételeket.
+        </p>
+        <ol className="space-y-2 list-decimal list-inside text-gray-300">
+          <li>A projekt részleteit és az árajánlatot írásban rögzítjük.</li>
+          <li>A határidők betartása közös felelősségünk.</li>
+          <li>A projekt lezárása után is biztosítok támogatást és karbantartást.</li>
+        </ol>
+      </section>
+    </Layout>
   );
 }

--- a/resources/js/route.js
+++ b/resources/js/route.js
@@ -1,5 +1,5 @@
 const routes = {
-  home: '/home',
+  home: '/',
   aboutme: '/about-me',
   services: '/services',
   prices: '/prices',


### PR DESCRIPTION
## Summary
- update the shared Layout component to derive the active path from Inertia and continue rendering the global menus
- wrap every React page component in the shared Layout so the main and footer menus appear on each screen
- align the front-end home route definition with the Laravel root path for correct menu highlighting

## Testing
- npm run build *(fails: Vite could not resolve the `react` package because it is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d16ecea4832dac436c9f4cce85c6