### PR TITLE
Fix inertia page resolution and remove unused React refresh

### DIFF
--- a/resources/js/App.jsx
+++ b/resources/js/App.jsx
@@ -3,9 +3,9 @@ import { createRoot } from 'react-dom/client';
 import { createInertiaApp } from '@inertiajs/react';
 
 createInertiaApp({
-  resolve: name => {
-    const pages = import.meta.glob('./Pages/**/*.jsx', { eager: true });
-    return pages[`./Pages/${name}.jsx`];
+  resolve: (name) => {
+    const pages = import.meta.glob('./pages/**/*.jsx', { eager: true });
+    return pages[`./pages/${name}.jsx`];
   },
   setup({ el, App, props }) {
     createRoot(el).render(<App {...props} />);

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -3,9 +3,9 @@ import { createRoot } from 'react-dom/client';
 import { createInertiaApp } from '@inertiajs/react';
 
 createInertiaApp({
-  resolve: name => {
-    const pages = import.meta.glob('./Pages/**/*.jsx', { eager: true });
-    return pages[`./Pages/${name}.jsx`];
+  resolve: (name) => {
+    const pages = import.meta.glob('./pages/**/*.jsx', { eager: true });
+    return pages[`./pages/${name}.jsx`];
   },
   setup({ el, App, props }) {
     createRoot(el).render(<App {...props} />);

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -9,7 +9,6 @@
       <link rel="preconnect" href="https://fonts.bunny.net">
       <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
-      @viteReactRefresh
       @vite(['resources/css/app.css', 'resources/js/app.jsx'])
       @inertiaHead
   </head>


### PR DESCRIPTION
## Summary
- correct the Inertia page resolver to look in the existing lowercase `pages` directory
- drop the `@viteReactRefresh` directive to prevent 404s for the missing `@react-refresh` runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb0c138910832db6e01cfeb35933a2