### PR TITLE
Add quote request navigation entry and page

### DIFF
--- a/resources/js/Components/MainMenu.jsx
+++ b/resources/js/Components/MainMenu.jsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import route from '../route.js';
 
-const menuItems = [
+const baseMenuItems = [
   { name: 'home', label: 'Főoldal' },
   { name: 'aboutme', label: 'Rólam' },
   { name: 'services', label: 'Szolgáltatások' },
   { name: 'prices', label: 'Árak' },
   { name: 'references', label: 'Referenciák' },
   { name: 'infos', label: 'Információk' },
-  { name: 'quote', label: 'Árajánlat' },
-  { name: 'contact', label: 'Kapcsolat' },
 ];
+
+const ctaItem = { name: 'quote', label: 'Árajánlat' };
+
+const trailingItems = [{ name: 'contact', label: 'Kapcsolat' }];
+
+const menuItems = [...baseMenuItems, ctaItem, ...trailingItems];
 
 export default function MainMenu({ activePath }) {
   return (

--- a/resources/js/pages/QuoteRequest.jsx
+++ b/resources/js/pages/QuoteRequest.jsx
@@ -2,8 +2,19 @@ import React from 'react';
 import { Head } from '@inertiajs/react';
 import Layout from '../Components/Layout.jsx';
 
-const inputClasses =
-  'w-full rounded-lg border border-gray-600 bg-transparent p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none transition';
+const inputClasses = [
+  'w-full',
+  'rounded-lg',
+  'border border-gray-700',
+  'bg-transparent',
+  'p-3',
+  'text-gray-200',
+  'focus:border-[#FF007A]',
+  'focus:ring-2',
+  'focus:ring-[#FF007A]',
+  'outline-none',
+  'transition',
+].join(' ');
 
 export default function QuoteRequest() {
   const handleSubmit = (event) => {
@@ -13,51 +24,45 @@ export default function QuoteRequest() {
   return (
     <Layout>
       <Head title="Árajánlat kérés" />
-      <section className="w-full px-6 py-20">
-        <div className="mx-auto max-w-4xl rounded-2xl border border-gray-700 bg-black/30 p-10 shadow-[0_0_45px_rgba(255,0,122,0.18)]">
-          <div className="mb-12 space-y-4 text-center">
-            <h2 className="text-4xl sm:text-5xl font-extrabold text-[#FF007A] drop-shadow-[0_0_20px_#ff007a]">
-              Árajánlat kérés
-            </h2>
-            <p className="text-lg text-gray-300">
-              Írd le néhány mondatban, mire van szükséged, és rövid időn belül személyre szabott ajánlattal
-              kereslek meg.
+      <section className="w-full px-6 py-16 lg:py-24">
+        <div className="mx-auto max-w-4xl rounded-2xl border border-gray-800 bg-black/40 p-10 shadow-[0_0_45px_rgba(255,0,122,0.2)]">
+          <header className="mb-12 text-center text-gray-300">
+            <p className="text-sm uppercase tracking-[0.3em] text-[#FF007A]">Kérj személyre szabott ajánlatot</p>
+            <h1 className="mt-4 text-4xl font-extrabold text-white sm:text-5xl">Árajánlat kérés</h1>
+            <p className="mt-6 text-base sm:text-lg text-gray-400">
+              Mondd el, mire van szükséged, én pedig egy részletes és személyre szabott ajánlattal kereslek meg a lehető
+              legrövidebb időn belül.
             </p>
-            <p className="text-sm text-gray-400">* A csillaggal jelölt mezők kitöltése kötelező.</p>
-          </div>
+            <p className="mt-3 text-xs text-gray-500">* A csillaggal jelölt mezők kitöltése kötelező.</p>
+          </header>
 
-          <form onSubmit={handleSubmit} className="space-y-8">
+          <form onSubmit={handleSubmit} className="space-y-8 text-gray-300">
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-              <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="name">
+              <label className="flex flex-col gap-2 text-sm" htmlFor="name">
                 Teljes név *
                 <input id="name" type="text" placeholder="Írd be a neved" required className={inputClasses} />
               </label>
-              <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="email">
+              <label className="flex flex-col gap-2 text-sm" htmlFor="email">
                 E-mail cím *
                 <input id="email" type="email" placeholder="Add meg az e-mail címed" required className={inputClasses} />
               </label>
             </div>
 
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-              <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="phone">
+              <label className="flex flex-col gap-2 text-sm" htmlFor="phone">
                 Telefonszám
                 <input id="phone" type="tel" placeholder="+36 20 123 4567" className={inputClasses} />
               </label>
-              <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="company">
+              <label className="flex flex-col gap-2 text-sm" htmlFor="company">
                 Cég / projekt neve
                 <input id="company" type="text" placeholder="Cégnév vagy projekt" className={inputClasses} />
               </label>
             </div>
 
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-              <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="service">
+              <label className="flex flex-col gap-2 text-sm" htmlFor="service">
                 Kívánt szolgáltatás *
-                <select
-                  id="service"
-                  required
-                  defaultValue=""
-                  className={`${inputClasses} bg-[#151522]`}
-                >
+                <select id="service" required defaultValue="" className={`${inputClasses} bg-[#151522]`}>
                   <option value="" disabled>
                     Válassz szolgáltatást
                   </option>
@@ -69,13 +74,9 @@ export default function QuoteRequest() {
                   <option value="egyedi">Egyedi fejlesztés</option>
                 </select>
               </label>
-              <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="budget">
+              <label className="flex flex-col gap-2 text-sm" htmlFor="budget">
                 Tervezett költségkeret
-                <select
-                  id="budget"
-                  defaultValue=""
-                  className={`${inputClasses} bg-[#151522]`}
-                >
+                <select id="budget" defaultValue="" className={`${inputClasses} bg-[#151522]`}>
                   <option value="" disabled>
                     Válassz kategóriát
                   </option>
@@ -88,30 +89,28 @@ export default function QuoteRequest() {
               </label>
             </div>
 
-            <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="timeline">
+            <label className="flex flex-col gap-2 text-sm" htmlFor="timeline">
               Tervezett határidő
               <input id="timeline" type="text" placeholder="Pl. 2024. június vége" className={inputClasses} />
             </label>
 
-            <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="message">
+            <label className="flex flex-col gap-2 text-sm" htmlFor="message">
               Projekt rövid leírása *
               <textarea
                 id="message"
                 rows="6"
                 required
-                placeholder="Írd le, milyen megoldást szeretnél, milyen funkciókra van szükség, illetve minden egyéb hasznos információt."
+                placeholder="Írd le, milyen megoldást szeretnél, milyen funkciókra van szükség és minden egyéb hasznos információt."
                 className={`${inputClasses} min-h-[160px]`}
               ></textarea>
             </label>
 
-            <div className="flex flex-col gap-4 text-sm text-gray-400 md:flex-row md:items-center md:justify-between">
-              <label className="inline-flex items-center gap-3 text-gray-300" htmlFor="privacy">
-                <input id="privacy" type="checkbox" className="h-4 w-4 accent-[#FF007A]" required />
-                Megismertem és elfogadom az adatkezelési tájékoztatót.
-              </label>
-            </div>
+            <label className="flex items-start gap-3 text-sm" htmlFor="privacy">
+              <input id="privacy" type="checkbox" className="mt-1 h-4 w-4 accent-[#FF007A]" required />
+              <span className="text-gray-400">Megismertem és elfogadom az adatkezelési tájékoztatót.</span>
+            </label>
 
-            <div className="flex flex-col items-stretch sm:flex-row sm:justify-end">
+            <div className="flex justify-end">
               <button
                 type="submit"
                 className="w-full sm:w-auto rounded-lg bg-[#FF007A] px-8 py-3 text-center font-semibold text-white shadow-[0_0_25px_#ff007a] transition hover:shadow-[0_0_40px_#ff007a]"


### PR DESCRIPTION
## Summary
- ensure the main navigation exposes an Árajánlat link directly before the Kapcsolat item
- rebuild the quote request page with an English file name, refreshed copy and layout, and a footer Elküldöm button

## Testing
- npm run build *(fails: local vite binary missing in container)*
- npm install *(fails: npm registry returned 403 for @emotion/react)*

------
https://chatgpt.com/codex/tasks/task_e_68d03636ee40832da37fabe11b936de5