### PR TITLE
Fix Docker database credentials for local stack

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ LOG_LEVEL=debug
 
 # Database
 DB_CONNECTION=mysql
-DB_HOST=progzone2-db
+DB_HOST=db
 DB_PORT=3306
 DB_DATABASE=progzone2
 DB_USERNAME=progzone2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,14 @@ services:
 
   db:
     image: mysql:8.0
+    platform: linux/arm64/v8
     container_name: progzone2-db
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: progzone2
       MYSQL_ROOT_PASSWORD: progzone2
       MYSQL_USER: progzone2
-      MYSQL_PASSWORD: laravel
+      MYSQL_PASSWORD: progzone2
     ports:
       - "3309:3306"
     volumes:
@@ -40,12 +41,13 @@ services:
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
+    platform: linux/arm64/v8
     container_name: progzone2-phpmyadmin
     restart: unless-stopped
     environment:
       PMA_HOST: db
       PMA_USER: root
-      PMA_PASSWORD: root
+      PMA_PASSWORD: progzone2
     ports:
       - "8082:80"
 


### PR DESCRIPTION
## Summary
- add ARM platform hints for the MySQL and phpMyAdmin containers
- align the configured MySQL user credentials across Docker services and the Laravel .env file
- point the Laravel database host to the Compose service name so the application can connect

## Testing
- not run (docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0609e0864832db824ece6b96cdf2b