### PR TITLE
Implement backend storage for quote and contact forms

### DIFF
--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ContactMessage;
+use App\Models\QuoteRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class FormController extends Controller
+{
+    /**
+     * Handle the incoming quote request form submission.
+     */
+    public function storeQuoteRequest(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:255'],
+            'company' => ['nullable', 'string', 'max:255'],
+            'service' => ['required', 'string', 'max:255'],
+            'budget' => ['nullable', 'string', 'max:255'],
+            'timeline' => ['nullable', 'string', 'max:255'],
+            'message' => ['required', 'string'],
+            'privacy' => ['accepted'],
+        ]);
+
+        $data['privacy'] = true;
+
+        QuoteRequest::create($data);
+
+        return redirect()
+            ->back()
+            ->with('success', 'Köszönjük, ajánlatkérésedet rögzítettük!');
+    }
+
+    /**
+     * Handle the incoming contact form submission.
+     */
+    public function storeContactMessage(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:255'],
+            'message' => ['required', 'string'],
+        ]);
+
+        ContactMessage::create($data);
+
+        return redirect()
+            ->back()
+            ->with('success', 'Üzenetedet sikeresen elküldtük!');
+    }
+}

--- a/app/Models/ContactMessage.php
+++ b/app/Models/ContactMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ContactMessage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'message',
+    ];
+}

--- a/app/Models/QuoteRequest.php
+++ b/app/Models/QuoteRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class QuoteRequest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'company',
+        'service',
+        'budget',
+        'timeline',
+        'message',
+        'privacy',
+    ];
+
+    protected $casts = [
+        'privacy' => 'boolean',
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Inertia\Inertia;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Inertia::share([
+            'flash' => fn () => [
+                'success' => session('success'),
+            ],
+        ]);
     }
 }

--- a/database/migrations/2024_01_01_100000_create_quote_requests_table.php
+++ b/database/migrations/2024_01_01_100000_create_quote_requests_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('quote_requests', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->string('phone')->nullable();
+            $table->string('company')->nullable();
+            $table->string('service');
+            $table->string('budget')->nullable();
+            $table->string('timeline')->nullable();
+            $table->text('message');
+            $table->boolean('privacy')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('quote_requests');
+    }
+};

--- a/database/migrations/2024_01_01_100001_create_contact_messages_table.php
+++ b/database/migrations/2024_01_01_100001_create_contact_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('contact_messages', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->string('phone')->nullable();
+            $table->text('message');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('contact_messages');
+    }
+};

--- a/resources/js/Components/Layout.jsx
+++ b/resources/js/Components/Layout.jsx
@@ -4,12 +4,26 @@ import Footer from './FooterMenu.jsx';
 import MainMenu from './MainMenu.jsx';
 
 export default function Layout({ activePath, children }) {
-  const { url } = usePage();
+  const { url, props } = usePage();
   const currentPath = activePath ?? url ?? '';
+  const successMessage = props?.flash?.success;
 
   return (
     <div className="min-h-screen text-[#FF007A] flex flex-col">
       <MainMenu activePath={currentPath} />
+
+      {successMessage && (
+        <div className="mx-auto mt-6 w-full max-w-4xl px-6">
+          <div
+            className="rounded-lg border border-green-400/30 bg-green-500/10 px-6 py-4 text-center text-sm font-medium text-green-200 shadow-[0_0_25px_rgba(34,197,94,0.45)]"
+            role="status"
+            aria-live="polite"
+          >
+            {successMessage}
+          </div>
+        </div>
+      )}
+
       <main className="flex-grow flex items-center justify-center">{children}</main>
       <Footer />
     </div>

--- a/resources/js/pages/Contact.jsx
+++ b/resources/js/pages/Contact.jsx
@@ -1,52 +1,108 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Head, router, usePage } from '@inertiajs/react';
 import Layout from '../Components/Layout.jsx';
+import route from '../route.js';
+
+const createInitialFormState = () => ({
+  name: '',
+  email: '',
+  phone: '',
+  message: '',
+});
 
 export default function Contact() {
+  const [formData, setFormData] = useState(createInitialFormState);
+  const [processing, setProcessing] = useState(false);
+  const { props } = usePage();
+  const errors = props?.errors ?? {};
+
+  const handleChange = (field) => (event) => {
+    setFormData((previous) => ({
+      ...previous,
+      [field]: event.target.value,
+    }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    router.post(route('contact-message.store'), formData, {
+      onStart: () => setProcessing(true),
+      onFinish: () => setProcessing(false),
+      onSuccess: () => setFormData(createInitialFormState()),
+    });
+  };
+
   return (
     <Layout>
+      <Head title="Kapcsolat" />
       <section className="max-w-4xl mx-auto px-6 py-20">
         <div className="rounded-2xl p-10 text-center">
           <h2 className="text-4xl sm:text-4xl font-extrabold text-center text-[#FF007A] mb-16 drop-shadow-[0_0_15px_#ff007a]">
             Kapcsolat
           </h2>
 
-          {/* Email infó középen felül */}
           <div className="mb-12">
             <h3 className="text-xl font-bold text-[#00f7ff]">📧 Email</h3>
             <p className="mt-2 text-gray-300 text-lg">info@progzone.de</p>
           </div>
 
-          {/* Form középen, szélesebb */}
-          <form className="space-y-6 max-w-3xl mx-auto">
+          <form className="space-y-6 max-w-3xl mx-auto" onSubmit={handleSubmit}>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <input
-                type="text"
-                placeholder="Név *"
-                className="w-full rounded-lg bg-transparent border border-gray-600 p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none"
-                required
-              />
-              <input
-                type="email"
-                placeholder="E-mail *"
-                className="w-full rounded-lg bg-transparent border border-gray-600 p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none"
-                required
-              />
+              <div className="flex flex-col gap-2">
+                <input
+                  type="text"
+                  placeholder="Név *"
+                  className="w-full rounded-lg bg-transparent border border-gray-600 p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none"
+                  required
+                  value={formData.name}
+                  onChange={handleChange('name')}
+                  aria-invalid={errors.name ? 'true' : 'false'}
+                />
+                {errors.name && <span className="text-xs text-red-400 text-left">{errors.name}</span>}
+              </div>
+              <div className="flex flex-col gap-2">
+                <input
+                  type="email"
+                  placeholder="E-mail *"
+                  className="w-full rounded-lg bg-transparent border border-gray-600 p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none"
+                  required
+                  value={formData.email}
+                  onChange={handleChange('email')}
+                  aria-invalid={errors.email ? 'true' : 'false'}
+                />
+                {errors.email && <span className="text-xs text-red-400 text-left">{errors.email}</span>}
+              </div>
             </div>
-            <input
-              type="tel"
-              placeholder="Telefonszám"
-              className="w-full rounded-lg bg-transparent border border-gray-600 p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none"
-            />
-            <textarea
-              placeholder="Üzenet"
-              rows="5"
-              className="w-full rounded-lg bg-transparent border border-gray-600 p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none"
-            ></textarea>
+            <div className="flex flex-col gap-2">
+              <input
+                type="tel"
+                placeholder="Telefonszám"
+                className="w-full rounded-lg bg-transparent border border-gray-600 p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none"
+                value={formData.phone}
+                onChange={handleChange('phone')}
+                aria-invalid={errors.phone ? 'true' : 'false'}
+              />
+              {errors.phone && <span className="text-xs text-red-400 text-left">{errors.phone}</span>}
+            </div>
+            <div className="flex flex-col gap-2">
+              <textarea
+                placeholder="Üzenet *"
+                rows="5"
+                className="w-full rounded-lg bg-transparent border border-gray-600 p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none"
+                required
+                value={formData.message}
+                onChange={handleChange('message')}
+                aria-invalid={errors.message ? 'true' : 'false'}
+              ></textarea>
+              {errors.message && <span className="text-xs text-red-400 text-left">{errors.message}</span>}
+            </div>
             <button
               type="submit"
-              className="w-full md:w-auto px-8 py-3 rounded-lg font-semibold bg-[#FF007A] text-white shadow-[0_0_20px_#ff007a] hover:shadow-[0_0_35px_#ff007a] transition"
+              className="w-full md:w-auto px-8 py-3 rounded-lg font-semibold bg-[#FF007A] text-white shadow-[0_0_20px_#ff007a] hover:shadow-[0_0_35px_#ff007a] transition disabled:cursor-not-allowed disabled:opacity-70"
+              disabled={processing}
             >
-              Küldés
+              {processing ? 'Küldés folyamatban…' : 'Küldés'}
             </button>
           </form>
         </div>

--- a/resources/js/pages/QuoteRequest.jsx
+++ b/resources/js/pages/QuoteRequest.jsx
@@ -1,13 +1,45 @@
-import React from 'react';
-import { Head } from '@inertiajs/react';
+import React, { useState } from 'react';
+import { Head, router, usePage } from '@inertiajs/react';
 import Layout from '../Components/Layout.jsx';
+import route from '../route.js';
 
 const inputClasses =
   'w-full rounded-lg border border-gray-600 bg-transparent p-3 text-gray-200 focus:border-[#FF007A] focus:ring-2 focus:ring-[#FF007A] outline-none transition';
 
+const createInitialFormState = () => ({
+  name: '',
+  email: '',
+  phone: '',
+  company: '',
+  service: '',
+  budget: '',
+  timeline: '',
+  message: '',
+  privacy: false,
+});
+
 export default function QuoteRequest() {
+  const [formData, setFormData] = useState(createInitialFormState);
+  const [processing, setProcessing] = useState(false);
+  const { props } = usePage();
+  const errors = props?.errors ?? {};
+
+  const handleChange = (field) => (event) => {
+    const value = field === 'privacy' ? event.target.checked : event.target.value;
+    setFormData((previous) => ({
+      ...previous,
+      [field]: value,
+    }));
+  };
+
   const handleSubmit = (event) => {
     event.preventDefault();
+
+    router.post(route('quote-request.store'), formData, {
+      onStart: () => setProcessing(true),
+      onFinish: () => setProcessing(false),
+      onSuccess: () => setFormData(createInitialFormState()),
+    });
   };
 
   return (
@@ -30,22 +62,60 @@ export default function QuoteRequest() {
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
               <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="name">
                 Teljes név *
-                <input id="name" type="text" placeholder="Írd be a neved" required className={inputClasses} />
+                <input
+                  id="name"
+                  type="text"
+                  placeholder="Írd be a neved"
+                  required
+                  className={inputClasses}
+                  value={formData.name}
+                  onChange={handleChange('name')}
+                  aria-invalid={errors.name ? 'true' : 'false'}
+                />
+                {errors.name && <span className="text-xs text-red-400">{errors.name}</span>}
               </label>
               <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="email">
                 E-mail cím *
-                <input id="email" type="email" placeholder="Add meg az e-mail címed" required className={inputClasses} />
+                <input
+                  id="email"
+                  type="email"
+                  placeholder="Add meg az e-mail címed"
+                  required
+                  className={inputClasses}
+                  value={formData.email}
+                  onChange={handleChange('email')}
+                  aria-invalid={errors.email ? 'true' : 'false'}
+                />
+                {errors.email && <span className="text-xs text-red-400">{errors.email}</span>}
               </label>
             </div>
 
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
               <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="phone">
                 Telefonszám
-                <input id="phone" type="tel" placeholder="+36 20 123 4567" className={inputClasses} />
+                <input
+                  id="phone"
+                  type="tel"
+                  placeholder="+36 20 123 4567"
+                  className={inputClasses}
+                  value={formData.phone}
+                  onChange={handleChange('phone')}
+                  aria-invalid={errors.phone ? 'true' : 'false'}
+                />
+                {errors.phone && <span className="text-xs text-red-400">{errors.phone}</span>}
               </label>
               <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="company">
                 Cég / projekt neve
-                <input id="company" type="text" placeholder="Cégnév vagy projekt" className={inputClasses} />
+                <input
+                  id="company"
+                  type="text"
+                  placeholder="Cégnév vagy projekt"
+                  className={inputClasses}
+                  value={formData.company}
+                  onChange={handleChange('company')}
+                  aria-invalid={errors.company ? 'true' : 'false'}
+                />
+                {errors.company && <span className="text-xs text-red-400">{errors.company}</span>}
               </label>
             </div>
 
@@ -55,8 +125,10 @@ export default function QuoteRequest() {
                 <select
                   id="service"
                   required
-                  defaultValue=""
+                  value={formData.service}
+                  onChange={handleChange('service')}
                   className={`${inputClasses} bg-[#151522]`}
+                  aria-invalid={errors.service ? 'true' : 'false'}
                 >
                   <option value="" disabled>
                     Válassz szolgáltatást
@@ -68,13 +140,16 @@ export default function QuoteRequest() {
                   <option value="marketing">Online marketing</option>
                   <option value="egyedi">Egyedi fejlesztés</option>
                 </select>
+                {errors.service && <span className="text-xs text-red-400">{errors.service}</span>}
               </label>
               <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="budget">
                 Tervezett költségkeret
                 <select
                   id="budget"
-                  defaultValue=""
+                  value={formData.budget}
+                  onChange={handleChange('budget')}
                   className={`${inputClasses} bg-[#151522]`}
+                  aria-invalid={errors.budget ? 'true' : 'false'}
                 >
                   <option value="" disabled>
                     Válassz kategóriát
@@ -85,12 +160,22 @@ export default function QuoteRequest() {
                   <option value="1000+">1 000 000 Ft felett</option>
                   <option value="bizonytalan">Még bizonytalan</option>
                 </select>
+                {errors.budget && <span className="text-xs text-red-400">{errors.budget}</span>}
               </label>
             </div>
 
             <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="timeline">
               Tervezett határidő
-              <input id="timeline" type="text" placeholder="Pl. 2024. június vége" className={inputClasses} />
+              <input
+                id="timeline"
+                type="text"
+                placeholder="Pl. 2024. június vége"
+                className={inputClasses}
+                value={formData.timeline}
+                onChange={handleChange('timeline')}
+                aria-invalid={errors.timeline ? 'true' : 'false'}
+              />
+              {errors.timeline && <span className="text-xs text-red-400">{errors.timeline}</span>}
             </label>
 
             <label className="flex flex-col gap-2 text-sm text-gray-300" htmlFor="message">
@@ -101,22 +186,36 @@ export default function QuoteRequest() {
                 required
                 placeholder="Írd le, milyen megoldást szeretnél, milyen funkciókra van szükség, illetve minden egyéb hasznos információt."
                 className={`${inputClasses} min-h-[160px]`}
+                value={formData.message}
+                onChange={handleChange('message')}
+                aria-invalid={errors.message ? 'true' : 'false'}
               ></textarea>
+              {errors.message && <span className="text-xs text-red-400">{errors.message}</span>}
             </label>
 
             <div className="flex flex-col gap-4 text-sm text-gray-400 md:flex-row md:items-center md:justify-between">
               <label className="inline-flex items-center gap-3 text-gray-300" htmlFor="privacy">
-                <input id="privacy" type="checkbox" className="h-4 w-4 accent-[#FF007A]" required />
+                <input
+                  id="privacy"
+                  type="checkbox"
+                  className="h-4 w-4 accent-[#FF007A]"
+                  required
+                  checked={formData.privacy}
+                  onChange={handleChange('privacy')}
+                  aria-invalid={errors.privacy ? 'true' : 'false'}
+                />
                 Megismertem és elfogadom az adatkezelési tájékoztatót.
               </label>
+              {errors.privacy && <span className="text-xs text-red-400">{errors.privacy}</span>}
             </div>
 
             <div className="flex flex-col items-stretch sm:flex-row sm:justify-end">
               <button
                 type="submit"
-                className="w-full sm:w-auto rounded-lg bg-[#FF007A] px-8 py-3 text-center font-semibold text-white shadow-[0_0_25px_#ff007a] transition hover:shadow-[0_0_40px_#ff007a]"
+                className="w-full sm:w-auto rounded-lg bg-[#FF007A] px-8 py-3 text-center font-semibold text-white shadow-[0_0_25px_#ff007a] transition hover:shadow-[0_0_40px_#ff007a] disabled:cursor-not-allowed disabled:opacity-70"
+                disabled={processing}
               >
-                Elküldöm
+                {processing ? 'Küldés folyamatban…' : 'Elküldöm'}
               </button>
             </div>
           </form>

--- a/resources/js/route.js
+++ b/resources/js/route.js
@@ -10,6 +10,8 @@ const routes = {
   privacy: '/privacy',
   terms: '/terms',
   impressum: '/impressum',
+  'quote-request.store': '/quote-request',
+  'contact-message.store': '/contact-message',
 };
 
 export default function route(name) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\FormController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -17,5 +18,8 @@ Route::get('/contact', fn () => Inertia::render('Contact'))->name('contact');
 Route::get('/privacy', fn () => Inertia::render('Privacy'))->name('privacy');
 Route::get('/terms', fn () => Inertia::render('Terms'))->name('terms');
 Route::get('/impressum', fn () => Inertia::render('Impressum'))->name('impressum');
+
+Route::post('/quote-request', [FormController::class, 'storeQuoteRequest'])->name('quote-request.store');
+Route::post('/contact-message', [FormController::class, 'storeContactMessage'])->name('contact-message.store');
 
 Route::fallback(fn () => Inertia::render('Home'));


### PR DESCRIPTION
## Summary
- add models, migrations, and a controller to persist quote requests and contact messages with validation and flash feedback
- expose flash messages to Inertia and surface them in the shared layout
- wire the quote request and contact React forms to submit via Inertia router.post and display validation errors

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f2aaec9c832dbce394df7700ef59