### PR TITLE
Fix locale middleware session usage

### DIFF
--- a/app/Http/Middleware/SetLocaleFromHost.php
+++ b/app/Http/Middleware/SetLocaleFromHost.php
@@ -15,7 +15,12 @@ class SetLocaleFromHost
     {
         $availableLocales = ['hu', 'de', 'en'];
 
-        $sessionLocale = $request->session()->get('locale');
+        $sessionLocale = null;
+
+        if ($request->hasSession()) {
+            $sessionLocale = $request->session()->get('locale');
+        }
+
         if ($sessionLocale && in_array($sessionLocale, $availableLocales, true)) {
             $locale = $sessionLocale;
         } else {
@@ -30,7 +35,9 @@ class SetLocaleFromHost
                 $locale = config('app.fallback_locale', 'hu');
             }
 
-            $request->session()->put('locale', $locale);
+            if ($request->hasSession()) {
+                $request->session()->put('locale', $locale);
+            }
         }
 
         App::setLocale($locale);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,10 +14,8 @@ return Application::configure(basePath: dirname(__DIR__))
         // Inertia middleware hozzáadása a web middleware stackhez
         $middleware->web(
             append: [
-                \Inertia\Middleware::class,
-            ],
-            prepend: [
                 \App\Http\Middleware\SetLocaleFromHost::class,
+                \Inertia\Middleware::class,
             ],
         );
     })


### PR DESCRIPTION
## Summary
- ensure locale middleware only interacts with the session when it is available
- adjust middleware registration so it runs after the framework session middleware

## Testing
- php artisan test *(fails: vendor autoload missing because Composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68d122bf0560832d92521bb7ebec5edb