### PR TITLE
Add migration to ensure locale column exists on prices table

### DIFF
--- a/database/migrations/2024_12_10_000000_add_locale_to_prices_table.php
+++ b/database/migrations/2024_12_10_000000_add_locale_to_prices_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('prices')) {
+            return;
+        }
+
+        $fallbackLocale = config('app.fallback_locale', 'hu');
+
+        if (! Schema::hasColumn('prices', 'locale')) {
+            Schema::table('prices', function (Blueprint $table) use ($fallbackLocale) {
+                $table->string('locale', 5)->default($fallbackLocale)->after('slug');
+            });
+        }
+
+        if (Schema::hasColumn('prices', 'locale')) {
+            DB::table('prices')
+                ->whereNull('locale')
+                ->update(['locale' => $fallbackLocale]);
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('prices')) {
+            return;
+        }
+
+        if (Schema::hasColumn('prices', 'locale')) {
+            Schema::table('prices', function (Blueprint $table) {
+                $table->dropColumn('locale');
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a follow-up migration that ensures the prices table has a locale column
- backfill missing locale values with the application fallback locale to prevent SQL errors

## Testing
- composer install *(fails: unable to reach github.com due to CONNECT tunnel 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d124ad8530832db989b63be4431eef