### PR TITLE
Load prices for current domain

### DIFF
--- a/app/Http/Controllers/PriceController.php
+++ b/app/Http/Controllers/PriceController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Price;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -14,12 +15,27 @@ class PriceController extends Controller
      */
     public function index(Request $request): Response
     {
-        $host = $request->getHost();
+        $domain = $request->getHost(); // pl. progzone.de
         $locale = app()->getLocale();
 
-        $prices = Price::forDomainAndLocale($host, $locale)
+        $rows = DB::table('prices')
+            ->when(
+                Price::hasLocaleColumn(),
+                fn ($query) => $query->where('locale', $locale)
+            )
+            ->where(function ($query) use ($domain) {
+                $query->whereNull('domain');
+
+                if ($domain) {
+                    $query->orWhere('domain', $domain);
+                }
+            })
             ->orderBy('position')
             ->get()
+            ->map(fn ($row) => (array) $row)
+            ->all();
+
+        $prices = Price::hydrate($rows)
             ->map(fn (Price $price) => [
                 'id' => $price->id,
                 'slug' => $price->slug,

--- a/app/Models/Price.php
+++ b/app/Models/Price.php
@@ -50,7 +50,7 @@ class Price extends Model
     /**
      * Determine if the prices table contains the locale column.
      */
-    protected static function hasLocaleColumn(): bool
+    public static function hasLocaleColumn(): bool
     {
         static $hasLocaleColumn;
 


### PR DESCRIPTION
## Summary
- fetch price rows for the current host using the database facade and hydrate them into models
- expose the Price::hasLocaleColumn helper so the controller can reuse the locale-aware filtering logic

## Testing
- php artisan test *(fails: vendor/autoload.php missing; composer install requires a GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68d19d611a98832da730042aa1ec21df