### PR TITLE
Include footer links in mobile navigation

### DIFF
--- a/resources/js/Components/FooterMenu.jsx
+++ b/resources/js/Components/FooterMenu.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import route from '../route.js';
 import useTranslations from '../lib/useTranslations.js';
 
-const footerLinks = [
+export const footerLinks = [
   { name: 'privacy', labelKey: 'footer.privacy', fallback: 'Privacy Policy' },
   { name: 'terms', labelKey: 'footer.terms', fallback: 'Terms' },
   { name: 'impressum', labelKey: 'footer.impressum', fallback: 'Impressum' },

--- a/resources/js/Components/MainMenu.jsx
+++ b/resources/js/Components/MainMenu.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import route from '../route.js';
 import LanguageSwitcher from './LanguageSwitcher.jsx';
+import { footerLinks } from './FooterMenu.jsx';
 import useTranslations from '../lib/useTranslations.js';
 
 const MenuIcon = ({ className }) => (
@@ -155,6 +156,22 @@ export default function MainMenu({ activePath }) {
             })}
           </ul>
         </nav>
+
+        <div className="border-t border-white/10 px-4 py-4">
+          <ul className="space-y-1">
+            {footerLinks.map((link) => (
+              <li key={link.name}>
+                <a
+                  href={route(link.name)}
+                  onClick={closeMenu}
+                  className="block rounded-lg px-4 py-2 text-base font-medium text-gray-300 transition-colors duration-200 hover:text-[#00f7ff] hover:bg-white/5"
+                >
+                  {t(link.labelKey, link.fallback)}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
 
         <div className="border-t border-white/10 p-4">
           <LanguageSwitcher />


### PR DESCRIPTION
## Summary
- export the footer link definitions for reuse across navigation
- extend the slide-out mobile menu with the footer links so legal pages stay accessible on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1a1b497d8832dbe8c07f527c56c93