### PR TITLE
Hide footer menu on mobile view

### DIFF
--- a/resources/js/Components/FooterMenu.jsx
+++ b/resources/js/Components/FooterMenu.jsx
@@ -14,7 +14,7 @@ export default function FooterMenu() {
   const copyright = t('footer.copyright', `© ${year} Progzone. All rights reserved.`).replace(':year', year);
 
   return (
-    <footer className="bg-gray-900 text-gray-400 text-sm py-6 mt-12">
+    <footer className="hidden bg-gray-900 text-gray-400 text-sm md:block py-6 mt-12">
       <div className="container mx-auto flex flex-col items-center justify-between px-4 sm:flex-row">
         <p className="mb-4 sm:mb-0">{copyright}</p>
         <div className="flex space-x-6">


### PR DESCRIPTION
## Summary
- hide the footer bar on small screens so navigation only appears in the hamburger menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1a36fd29c832db18b5f1d853eeaa8