### PR TITLE
Remove placeholder reference card

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -543,11 +543,6 @@
         "title": "Versenybikini Herstellung",
         "description": "Komplettes Branding und responsive Webpräsenz.",
         "cta": "Website ansehen"
-      },
-      {
-        "type": "card",
-        "title": "Gartenbau-Plattform",
-        "description": "Entwicklung eines benutzerfreundlichen Dashboards und Integrationen für Start-ups."
       }
     ]
   },

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -543,11 +543,6 @@
         "title": "Custom competition bikinis",
         "description": "Complete branding and responsive website.",
         "cta": "View website"
-      },
-      {
-        "type": "card",
-        "title": "Garden platform",
-        "description": "Development of a user-friendly dashboard and integrations for start-ups."
       }
     ]
   },

--- a/resources/lang/hu.json
+++ b/resources/lang/hu.json
@@ -547,10 +547,6 @@
         "cta": "Megnézem a weboldalt"
       },
       {
-        "type": "card",
-        "title": "Kertészeti weboldal"
-      },
-      {
         "type": "lightbox",
         "image": "/img/action.jpg",
         "title": "Szórólap",


### PR DESCRIPTION
## Summary
- remove the untranslated reference card entry from the Hungarian locale to prevent rendering an empty grey tile
- keep the references lists aligned by removing the same placeholder card from the English and German locales

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2fc63bf78832d9ee7006ce415e1cf