### PR TITLE
Configure Mailjet SMTP support

### DIFF
--- a/.env
+++ b/.env
@@ -24,15 +24,22 @@ QUEUE_CONNECTION=sync
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
-# Mail (opcionális, majd később)
-MAIL_MAILER=smtp
-MAIL_HOST=mailpit
-MAIL_PORT=1025
-MAIL_USERNAME=null
-MAIL_PASSWORD=null
-MAIL_ENCRYPTION=null
+# Mail (Mailjet SMTP konfiguráció)
+MAIL_MAILER=mailjet
+MAIL_HOST=in-v3.mailjet.com
+MAIL_PORT=587
+MAIL_USERNAME=your-mailjet-api-key
+MAIL_PASSWORD=your-mailjet-secret-key
+MAIL_ENCRYPTION=tls
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
+
+# Opcionális Mailjet specifikus beállítások
+# MAILJET_HOST=in-v3.mailjet.com
+# MAILJET_PORT=587
+# MAILJET_USERNAME=
+# MAILJET_PASSWORD=
+# MAILJET_SCHEME=tls
 
 # Vite / Frontend
 VITE_DEV_SERVER_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ Laravel is a web application framework with expressive, elegant syntax. We belie
 
 Laravel is accessible, powerful, and provides tools required for large, robust applications.
 
+## Mailjet SMTP használata
+
+Az alkalmazás levélküldését a [Mailjet](https://www.mailjet.com/) SMTP szolgáltatása végzi. A csomagküldéshez állítsd be a következő környezeti változókat a `.env` fájlban:
+
+```env
+MAIL_MAILER=mailjet
+MAIL_HOST=in-v3.mailjet.com
+MAIL_PORT=587
+MAIL_USERNAME=your-mailjet-api-key
+MAIL_PASSWORD=your-mailjet-secret-key
+MAIL_ENCRYPTION=tls
+```
+
+Szükség esetén külön `MAILJET_*` változókkal (például `MAILJET_HOST`, `MAILJET_USERNAME`) felülírhatod az alapértelmezett értékeket. Ne felejtsd el a Mailjet fiókodhoz tartozó API kulcsokat és feladói e-mail címet megadni.
+
 ## Learning Laravel
 
 Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.

--- a/config/mail.php
+++ b/config/mail.php
@@ -39,13 +39,25 @@ return [
 
         'smtp' => [
             'transport' => 'smtp',
-            'scheme' => env('MAIL_SCHEME'),
+            'scheme' => env('MAIL_SCHEME', env('MAIL_ENCRYPTION')),
             'url' => env('MAIL_URL'),
             'host' => env('MAIL_HOST', '127.0.0.1'),
             'port' => env('MAIL_PORT', 2525),
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
+            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url((string) env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
+        ],
+
+        'mailjet' => [
+            'transport' => 'smtp',
+            'scheme' => env('MAILJET_SCHEME', env('MAIL_SCHEME', env('MAIL_ENCRYPTION'))),
+            'url' => env('MAILJET_URL', env('MAIL_URL')),
+            'host' => env('MAILJET_HOST', 'in-v3.mailjet.com'),
+            'port' => env('MAILJET_PORT', 587),
+            'username' => env('MAILJET_USERNAME', env('MAIL_USERNAME')),
+            'password' => env('MAILJET_PASSWORD', env('MAIL_PASSWORD')),
+            'timeout' => env('MAILJET_TIMEOUT'),
             'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url((string) env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
         ],
 


### PR DESCRIPTION
## Summary
- add a dedicated Mailjet SMTP mailer definition with sensible defaults
- update the example environment values to point at Mailjet's SMTP service and expose optional overrides
- document the Mailjet configuration steps in the README

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d386dedd1c832d816c742bf34af76a