### PR TITLE
Fix price slug mapping on Prices page

### DIFF
--- a/resources/js/pages/Prices.jsx
+++ b/resources/js/pages/Prices.jsx
@@ -14,9 +14,9 @@ export default function Prices({ prices = {} }) {
 
   // Fordítási kulcs → adatbázis slug leképezés
   const slugMap = {
-    wordpress: 'wordpress',
-    webshop: 'woocommerce',
-    custom: 'egyedifejlesztes',
+    wordpress: 'wordpress-website',
+    webshop: 'woocommerce-store',
+    custom: 'custom-website',
     marketing: 'marketing',
   };
 


### PR DESCRIPTION
## Summary
- correct the slug mappings on the Prices page so the database price entries are found

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3ae707aa4832d8826a242f5b2eb77