### PR TITLE
Fix price placeholders to use database values

### DIFF
--- a/app/Http/Controllers/PriceController.php
+++ b/app/Http/Controllers/PriceController.php
@@ -26,29 +26,21 @@ class PriceController extends Controller
             ->mapWithKeys(function (Price $price) {
                 return [
                     // FONTOS: a slug legyen a kulcs
-                    $price->slug ?? 'extra' => array_merge(
-                        Arr::only(
-                            $price->toArray(),
-                            [
-                                'slug',
-                                'locale',
-                                'domain',
-                                'title',
-                                'description',
-                                'feature_heading',
-                                'features',
-                                'price_label',
-                                'currency',
-                                'extras',
-                                'position',
-                            ]
-                        ),
+                    $price->slug ?? 'extra' => Arr::only(
+                        $price->toArray(),
                         [
-                            // Fix árértékek a placeholder-ekhez
-                            'domain_price'  => '3.000 Ft/év',
-                            'hosting_price' => '10.000 Ft/év',
-                            'plugin_price'  => '20.000–50.000 Ft',
-                            'hourly_rate'   => '10.000 Ft/óra',
+                            'slug',
+                            'locale',
+                            'domain',
+                            'title',
+                            'description',
+                            'feature_heading',
+                            'features',
+                            'price_label',
+                            'price_value',
+                            'currency',
+                            'extras',
+                            'position',
                         ]
                     ),
                 ];


### PR DESCRIPTION
## Summary
- expose the numeric price_value alongside other fields when building the price response
- format price placeholders on the Prices page using the related price entries and replace the translation tokens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3f462b1a4832d90db79278bd93305