### PR TITLE
Set domain specific default locales

### DIFF
--- a/app/Http/Middleware/SetLocaleFromHost.php
+++ b/app/Http/Middleware/SetLocaleFromHost.php
@@ -25,11 +25,16 @@ class SetLocaleFromHost
             $locale = $sessionLocale;
         } else {
             $host = $request->getHost();
-            $locale = match ($host) {
-                'progzone.de', 'bitbau.ch' => 'de',
+            $hostLocaleMap = [
+                'progzone.de' => 'de',
+                'www.progzone.de' => 'de',
+                'bitbau.ch' => 'de',
+                'www.bitbau.ch' => 'de',
                 'progzone.hu' => 'hu',
-                default => config('app.fallback_locale', 'hu'),
-            };
+                'www.progzone.hu' => 'hu',
+            ];
+
+            $locale = $hostLocaleMap[$host] ?? config('app.fallback_locale', 'hu');
 
             if (! in_array($locale, $availableLocales, true)) {
                 $locale = config('app.fallback_locale', 'hu');


### PR DESCRIPTION
## Summary
- update the locale middleware to use an explicit domain to locale map
- add support for www-prefixed hostnames so the correct default locale is used

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fbfe25c4832dba85132b2094be96