### PR TITLE
Fix mobile LanguageSwitcher dropdown placement

### DIFF
--- a/resources/js/Components/LanguageSwitcher.jsx
+++ b/resources/js/Components/LanguageSwitcher.jsx
@@ -60,7 +60,9 @@ export default function LanguageSwitcher() {
       </button>
 
       {open && (
-        <ul className="absolute right-0 mt-2 w-40 rounded-lg border border-[#FF007A]/40 bg-[#121317] shadow-lg">
+        <ul
+          className="absolute right-0 bottom-full mb-2 w-40 rounded-lg border border-[#FF007A]/40 bg-[#121317] shadow-lg md:bottom-auto md:top-full md:mb-0 md:mt-2"
+        >
           {locales.map((item) => (
             <li key={item.code}>
               <button


### PR DESCRIPTION
## Summary
- make the language switcher dropdown open upward by default so it remains visible on small screens
- keep the desktop behaviour by reverting the dropdown to open downward on medium and larger viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d785e18c5c832d8631e92fa3e06e85