### PR TITLE
Relocate language switcher in mobile menu

### DIFF
--- a/resources/js/Components/LanguageSwitcher.jsx
+++ b/resources/js/Components/LanguageSwitcher.jsx
@@ -61,7 +61,7 @@ export default function LanguageSwitcher() {
 
       {open && (
         <ul
-          className="absolute right-0 bottom-full mb-2 w-40 rounded-lg border border-[#FF007A]/40 bg-[#121317] shadow-lg md:bottom-auto md:top-full md:mb-0 md:mt-2"
+          className="absolute right-0 top-full mt-2 w-40 rounded-lg border border-[#FF007A]/40 bg-[#121317] shadow-lg"
         >
           {locales.map((item) => (
             <li key={item.code}>

--- a/resources/js/Components/MainMenu.jsx
+++ b/resources/js/Components/MainMenu.jsx
@@ -119,16 +119,19 @@ export default function MainMenu({ activePath }) {
           isMenuOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
-        <div className="flex items-center justify-between border-b border-white/10 p-4">
+        <div className="flex items-center gap-3 border-b border-white/10 p-4">
           <span className="text-lg font-semibold text-white">{t('menu.title', 'Menu')}</span>
-          <button
-            type="button"
-            onClick={closeMenu}
-            className="rounded-md p-2 text-[#FF007A] transition hover:text-[#00f7ff] focus:outline-none focus:ring-2 focus:ring-[#00f7ff] focus:ring-offset-2 focus:ring-offset-[#141422]"
-            aria-label="Close navigation menu"
-          >
-            <CloseIcon className="h-6 w-6" />
-          </button>
+          <div className="ml-auto flex items-center gap-3">
+            <LanguageSwitcher />
+            <button
+              type="button"
+              onClick={closeMenu}
+              className="rounded-md p-2 text-[#FF007A] transition hover:text-[#00f7ff] focus:outline-none focus:ring-2 focus:ring-[#00f7ff] focus:ring-offset-2 focus:ring-offset-[#141422]"
+              aria-label="Close navigation menu"
+            >
+              <CloseIcon className="h-6 w-6" />
+            </button>
+          </div>
         </div>
 
         <nav className="flex-1 overflow-y-auto py-4">
@@ -171,10 +174,6 @@ export default function MainMenu({ activePath }) {
               </li>
             ))}
           </ul>
-        </div>
-
-        <div className="border-t border-white/10 p-4">
-          <LanguageSwitcher />
         </div>
       </aside>
     </header>


### PR DESCRIPTION
## Summary
- move the mobile language switcher to the header of the hamburger menu for better visibility
- adjust the language switcher dropdown to open downward in all viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7972c1208832dba167ccfd0afaf39