### PR TITLE
Fix inertia middleware registration to restore Inertia pages

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Inertia\Middleware;
+
+class HandleInertiaRequests extends Middleware
+{
+    /**
+     * The root template that is loaded on the first page visit.
+     */
+    protected $rootView = 'app';
+
+    /**
+     * Determine the current asset version.
+     */
+    public function version(Request $request): ?string
+    {
+        return parent::version($request);
+    }
+
+    /**
+     * Define the props that are shared by default.
+     */
+    public function share(Request $request): array
+    {
+        return array_merge(parent::share($request), [
+            'locale' => app()->getLocale(),
+        ]);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,7 +15,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(
             append: [
                 \App\Http\Middleware\SetLocaleFromHost::class,
-                \Inertia\Middleware::class,
+                \App\Http\Middleware\HandleInertiaRequests::class,
             ],
         );
     })


### PR DESCRIPTION
## Summary
- add an application-specific Inertia middleware implementation
- register the concrete middleware in the web stack instead of the abstract base class

## Testing
- unable to run automated tests (Composer install requires GitHub access)

------
https://chatgpt.com/codex/tasks/task_e_68d7a1e7a34c832d83902657e4367d97