### PR TITLE
Add localized footer menu heading

### DIFF
--- a/resources/js/Components/FooterMenu.jsx
+++ b/resources/js/Components/FooterMenu.jsx
@@ -12,17 +12,23 @@ export default function FooterMenu() {
   const { t } = useTranslations();
   const year = new Date().getFullYear();
   const copyright = t('footer.copyright', `© ${year} Progzone. All rights reserved.`).replace(':year', year);
+  const footerMenuTitle = t('footer.menu_title', 'Footer Menu');
 
   return (
     <footer className="hidden bg-gray-900 text-gray-400 text-sm md:block py-6 mt-12">
       <div className="container mx-auto flex flex-col items-center justify-between px-4 sm:flex-row">
         <p className="mb-4 sm:mb-0">{copyright}</p>
-        <div className="flex space-x-6">
-          {footerLinks.map((link) => (
-            <a key={link.name} href={route(link.name)} className="hover:text-pink-400">
-              {t(link.labelKey, link.fallback)}
-            </a>
-          ))}
+        <div className="flex flex-col items-center space-y-2 sm:items-end">
+          <p className="text-lg font-semibold uppercase tracking-widest text-pink-400">
+            {footerMenuTitle}
+          </p>
+          <div className="flex space-x-6">
+            {footerLinks.map((link) => (
+              <a key={link.name} href={route(link.name)} className="hover:text-pink-400">
+                {t(link.labelKey, link.fallback)}
+              </a>
+            ))}
+          </div>
         </div>
       </div>
     </footer>

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -21,6 +21,7 @@
     "privacy": "Datenschutzerklärung",
     "terms": "Allgemeine Geschäftsbedingungen",
     "impressum": "Impressum",
+    "menu_title": "Footer-Menü",
     "copyright": "© :year Progzone. Alle Rechte vorbehalten."
   },
   "home": {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -21,6 +21,7 @@
     "privacy": "Privacy Policy",
     "terms": "Terms & Conditions",
     "impressum": "Imprint",
+    "menu_title": "Footer menu",
     "copyright": "© :year Progzone. All rights reserved."
   },
   "home": {

--- a/resources/lang/hu.json
+++ b/resources/lang/hu.json
@@ -21,6 +21,7 @@
     "privacy": "Adatvédelmi szerződés",
     "terms": "ÁSZF",
     "impressum": "Impresszum",
+    "menu_title": "Footer menü",
     "copyright": "© :year Progzone. Minden jog fenntartva."
   },
   "home": {


### PR DESCRIPTION
## Summary
- display a localized "Footer menu" heading above the footer navigation links
- add Hungarian, English, and German translations for the new footer label

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7abedaadc832db04168a4639ddb3a