### PR TITLE
Fix form state initialization for contact and quote pages

### DIFF
--- a/resources/js/pages/Contact.jsx
+++ b/resources/js/pages/Contact.jsx
@@ -12,7 +12,7 @@ const createInitialFormState = () => ({
 });
 
 export default function Contact() {
-  const [formData, setFormData] = useState(createInitialFormState);
+  const [formData, setFormData] = useState(() => createInitialFormState());
   const [processing, setProcessing] = useState(false);
   const { props } = usePage();
   const errors = props?.errors ?? {};

--- a/resources/js/pages/QuoteRequest.jsx
+++ b/resources/js/pages/QuoteRequest.jsx
@@ -34,7 +34,7 @@ const createInitialFormState = () => ({
 });
 
 export default function QuoteRequest() {
-  const [formData, setFormData] = useState(createInitialFormState);
+  const [formData, setFormData] = useState(() => createInitialFormState());
   const [processing, setProcessing] = useState(false);
   const { props } = usePage();
   const errors = props?.errors ?? {};


### PR DESCRIPTION
## Summary
- ensure the contact form initializes its state from a freshly created object
- initialize the quote request form with a new state object for consistent defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8d15894d4832d8d41fb67015bee66