### PR TITLE
Add React refresh preamble to layout

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -9,6 +9,7 @@
       <link rel="preconnect" href="https://fonts.bunny.net">
       <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
+      @viteReactRefresh
       @vite(['resources/css/app.css', 'resources/js/app.jsx'])
       @inertiaHead
   </head>


### PR DESCRIPTION
## Summary
- insert the @viteReactRefresh directive into the Inertia app layout so the React Fast Refresh preamble loads during development

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8db52ee48832dbc9a5dc8a29366fb