### PR TITLE
Ensure price aliases are available on the Prices page

### DIFF
--- a/app/Http/Controllers/PriceController.php
+++ b/app/Http/Controllers/PriceController.php
@@ -18,32 +18,44 @@ class PriceController extends Controller
         $domain = $request->getHost(); // pl. progzone.de
         $locale = app()->getLocale();
 
+        $allowedAttributes = [
+            'slug',
+            'locale',
+            'domain',
+            'title',
+            'description',
+            'feature_heading',
+            'features',
+            'price_label',
+            'price_value',
+            'currency',
+            'extras',
+            'position',
+        ];
+
+        $aliasMap = [
+            'domain' => ['domain_price'],
+            'hosting' => ['hosting_price'],
+            'plugin' => ['plugin_price'],
+            'extraFunctionsDev' => ['hourly_rate'],
+        ];
+
         // Árlista domain + nyelv szerint
-        $prices = Price::query()
+        $prices = [];
+
+        Price::query()
             ->forDomainAndLocale($domain, $locale)
             ->orderBy('position')
             ->get()
-            ->mapWithKeys(function (Price $price) {
-                return [
-                    // FONTOS: a slug legyen a kulcs
-                    $price->slug ?? 'extra' => Arr::only(
-                        $price->toArray(),
-                        [
-                            'slug',
-                            'locale',
-                            'domain',
-                            'title',
-                            'description',
-                            'feature_heading',
-                            'features',
-                            'price_label',
-                            'price_value',
-                            'currency',
-                            'extras',
-                            'position',
-                        ]
-                    ),
-                ];
+            ->each(function (Price $price) use (&$prices, $allowedAttributes, $aliasMap) {
+                $slug = $price->slug ?: 'extra';
+                $data = Arr::only($price->toArray(), $allowedAttributes);
+
+                $prices[$slug] = $data;
+
+                foreach ($aliasMap[$slug] ?? [] as $alias) {
+                    $prices[$alias] = $data;
+                }
             });
 
         return Inertia::render('Prices', [


### PR DESCRIPTION
## Summary
- build the prices payload as a plain associative array instead of a collection
- expose alias keys (domain_price, hosting_price, plugin_price, hourly_rate) alongside their original slugs
- keep the frontend placeholder replacement working across production domains

## Testing
- php artisan test *(fails: vendor directory is missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28db75d90832d95b84c004dc2e627