### PR TITLE
Normalize domains when loading prices and map Swiss locale

### DIFF
--- a/app/Http/Controllers/PriceController.php
+++ b/app/Http/Controllers/PriceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Price;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -15,7 +16,7 @@ class PriceController extends Controller
      */
     public function index(Request $request): Response
     {
-        $domain = $request->getHost(); // pl. progzone.de
+        $domain = $this->normalizeDomain($request->getHost()); // pl. progzone.de
         $locale = app()->getLocale();
 
         $allowedAttributes = [
@@ -62,5 +63,23 @@ class PriceController extends Controller
         return Inertia::render('Prices', [
             'prices' => $prices,
         ]);
+    }
+
+    /**
+     * Removes common subdomain prefixes (e.g. www.) and lowercases the domain name.
+     */
+    protected function normalizeDomain(?string $domain): ?string
+    {
+        if ($domain === null) {
+            return null;
+        }
+
+        $normalized = Str::lower($domain);
+
+        if (Str::startsWith($normalized, 'www.')) {
+            $normalized = Str::substr($normalized, 4);
+        }
+
+        return $normalized;
     }
 }

--- a/app/Http/Middleware/SetLocaleFromHost.php
+++ b/app/Http/Middleware/SetLocaleFromHost.php
@@ -13,7 +13,7 @@ class SetLocaleFromHost
      */
     public function handle(Request $request, Closure $next)
     {
-        $availableLocales = ['hu', 'de', 'en'];
+        $availableLocales = ['hu', 'de', 'de-CH', 'en'];
 
         $sessionLocale = null;
 
@@ -28,8 +28,8 @@ class SetLocaleFromHost
             $hostLocaleMap = [
                 'progzone.de' => 'de',
                 'www.progzone.de' => 'de',
-                'bitbau.ch' => 'de',
-                'www.bitbau.ch' => 'de',
+                'bitbau.ch' => 'de-CH',
+                'www.bitbau.ch' => 'de-CH',
                 'progzone.hu' => 'hu',
                 'www.progzone.hu' => 'hu',
             ];


### PR DESCRIPTION
## Summary
- normalize the incoming host before querying prices so production domains with www prefixes match database records
- add a helper method in the price controller to centralize the normalization logic
- map bitbau.ch hosts to the Swiss German locale so their price entries match the database records

## Testing
- ./vendor/bin/phpunit *(fails: binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5484f5a8c832db10a6acbdb1e31cc