### PR TITLE
Add configurable fallback domain support for price lookup

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,10 @@ APP_KEY=base64:HNo+POA7XyHuv8etFD4KsPT3X9ff2fTncaR8G2L3N6c=
 APP_DEBUG=true
 APP_URL=http://localhost:8020
 
+# Comma separated list of domains to use as a fallback when the current host
+# has no dedicated price entries. Example: progzone.hu,progzone.de
+PRICE_FALLBACK_DOMAINS=
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug

--- a/.env.production
+++ b/.env.production
@@ -4,6 +4,9 @@ APP_KEY=base64:HNo+POA7XyHuv8etFD4KsPT3X9ff2fTncaR8G2L3N6c=
 APP_DEBUG=false
 APP_URL=https://progzone.hu   # ← állítsd a tényleges domainre
 
+# Fallback domains for price lookup when the current host has no entries
+PRICE_FALLBACK_DOMAINS=progzone.hu,progzone.de
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=error   # production-ban elég az error

--- a/config/prices.php
+++ b/config/prices.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Price fallback domains
+    |--------------------------------------------------------------------------
+    |
+    | When a request is served from a domain that does not have dedicated
+    | entries in the prices table we can fall back to one or more predefined
+    | domains. Provide a comma separated list of domains via the
+    | PRICE_FALLBACK_DOMAINS environment variable (e.g. "progzone.hu,progzone.de").
+    */
+    'fallback_domains' => array_values(array_filter(array_map(
+        static fn (string $domain) => trim($domain),
+        explode(',', env('PRICE_FALLBACK_DOMAINS', ''))
+    ))),
+];


### PR DESCRIPTION
## Summary
- add reusable helper to collect prices and try configured fallback domains when the active host has no entries
- introduce a prices configuration file with an environment-driven fallback domain list
- document the PRICE_FALLBACK_DOMAINS setting in the environment templates for local and production setups

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e59235042c832db63b4efb2bf48d02