### PR TITLE
Adjust Layout flash success message placement

### DIFF
--- a/resources/js/Components/Layout.jsx
+++ b/resources/js/Components/Layout.jsx
@@ -12,19 +12,22 @@ export default function Layout({ activePath, children }) {
     <div className="min-h-screen text-[#FF007A] flex flex-col">
       <MainMenu activePath={currentPath} />
 
-      {successMessage && (
-        <div className="mx-auto mt-6 w-full max-w-4xl px-6">
-          <div
-            className="rounded-lg border border-green-400/30 bg-green-500/10 px-6 py-4 text-center text-sm font-medium text-green-200 shadow-[0_0_25px_rgba(34,197,94,0.45)]"
-            role="status"
-            aria-live="polite"
-          >
-            {successMessage}
+      <main className="flex-grow flex flex-col items-center justify-center w-full">
+        {successMessage && (
+          <div className="mx-auto mt-6 w-full max-w-4xl px-6">
+            <div
+              className="rounded-lg border border-green-400/30 bg-green-500/10 px-6 py-4 text-center text-sm font-medium text-green-200 shadow-[0_0_25px_rgba(34,197,94,0.45)]"
+              role="status"
+              aria-live="polite"
+            >
+              {successMessage}
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
-      <main className="flex-grow flex items-center justify-center">{children}</main>
+        {children}
+      </main>
+
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- render the flash success message once within the main content area and keep styling intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebfb529330832da90d1d60d3f8e4d8